### PR TITLE
Adding ability to 'rewind' the outlet registry. Useful for resetting …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/spec/basic.js
+++ b/spec/basic.js
@@ -277,6 +277,7 @@ describe("react-outlet", function() {
             );
             expect(outlet_registry.outlets.hasOwnProperty(id)).toBeTruthy();
             Outlet.rewind();
+            expect(outlet_registry.outlets != null && typeof outlet_registry.outlets === "object" && !Array.isArray(outlet_registry.outlets)).toBeTruthy();
             expect(Object.keys(outlet_registry.outlets).length).toEqual(0);
         });
 

--- a/spec/basic.js
+++ b/spec/basic.js
@@ -267,6 +267,19 @@ describe("react-outlet", function() {
 
             expect(outlet_registry.outlets.hasOwnProperty(id)).toBeFalsy();
         });
+
+        it("supports clearing all outlets from the registry", function() {
+            var id = Outlet.new_outlet_id();
+            TestUtils.renderIntoDocument(
+                <TestDiv>
+                    <Outlet outletId={ id } className="outlet-content" />
+                </TestDiv>
+            );
+            expect(outlet_registry.outlets.hasOwnProperty(id)).toBeTruthy();
+            Outlet.rewind();
+            expect(Object.keys(outlet_registry.outlets).length).toEqual(0);
+        });
+
     });
 
     describe("Plug", function() {

--- a/src/outlet.js
+++ b/src/outlet.js
@@ -3,7 +3,8 @@ var registry = require("./outlet_registry");
 
 var Outlet = React.createClass({
     statics: {
-        new_outlet_id: registry.generate_id.bind(registry)
+        new_outlet_id: registry.generate_id.bind(registry),
+        rewind: registry.rewind.bind(registry)
     },
 
     propTypes: {

--- a/src/outlet_registry.js
+++ b/src/outlet_registry.js
@@ -59,4 +59,9 @@ OutletRegistry.prototype.update = function(outlet_id, component) {
     }
 };
 
+OutletRegistry.prototype.rewind = function(){
+    this.outlets = [];
+    this._unique_id_gen = 0;
+};
+
 module.exports = new OutletRegistry();

--- a/src/outlet_registry.js
+++ b/src/outlet_registry.js
@@ -60,8 +60,7 @@ OutletRegistry.prototype.update = function(outlet_id, component) {
 };
 
 OutletRegistry.prototype.rewind = function(){
-    this.outlets = [];
-    this._unique_id_gen = 0;
+    this.outlets = {};
 };
 
 module.exports = new OutletRegistry();


### PR DESCRIPTION
Currently this component doesn't work with server side rendering because the outlet registry maintains its state between server-side renders. This PR adds a new method to Outlet, 'rewind', that resets the registry. This method should be called server-side before each render.
