### PR TITLE
Remove outletId from props

### DIFF
--- a/src/outlet.js
+++ b/src/outlet.js
@@ -32,7 +32,9 @@ var Outlet = React.createClass({
 
     update: function(children) {
         if (children) {
-            this.setState({ children: React.createElement("div", this.props, children) });
+            var props = Object.assign({}, this.props);
+            delete props.outletId;
+            this.setState({ children: React.createElement("div", props, children) });
         } else {
             this.setState({ children: null });
         }


### PR DESCRIPTION
`div` shouldn't be receiving `outletId` not a valid `div` attribute.
Starting from `react v15.2.0`, react will warn about invalid DOM attributes passed to DOM nodes. 

Fixing this as per recommended in https://gist.github.com/jimfb/d99e0678e9da715ccf6454961ef04d1b
